### PR TITLE
Fixed docs link

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -135,7 +135,7 @@ Yes! pytest-flakefighters can be combined with other flaky test plugins:
    :maxdepth: 2
 
    Source code <https://github.com/test-flare/pytest-flakefighters/>
-   Documentation <https://causal-testing-framework.readthedocs.io/en/latest/>
+   Documentation <https://pytest-flakefighters.readthedocs.io/en/latest/>
    PyPI <https://pypi.org/project/pytest-flakefighters/>
    TestFLARE Homepage <https://test-flare.github.io/>
 


### PR DESCRIPTION
@MgnMtn noticed that the docs link pointed to the causal testing framework (copy paste error on my part, sorry!) so I've fixed that.